### PR TITLE
(Non-working) solution to exercise 1.1

### DIFF
--- a/smbd/src/test/scala/StringyMapBigDataSpec.scala
+++ b/smbd/src/test/scala/StringyMapBigDataSpec.scala
@@ -2,10 +2,24 @@
 // License: http://www.apache.org/licenses/LICENSE-2.0
 package s4m.exercise1
 
+import s4m.smbd.api.BigDataFormat
+import shapeless._
 import org.scalatest._
+import s4m.smbd.impl._
+
+case class Teapot(a: String, b: Int, c: Boolean)
 
 class StringyMapBigDataSpec extends FlatSpec with Matchers {
-  "StringyMapBigDataSpec" should "marshall all the things!" in {
-    fail
+
+  "StringyMapBigData" should "marshall a case class" in {
+    val teapot = Teapot("foo", 42, true)
+    val format = implicitly[BigDataFormat[Teapot]]
+    val stringyMap = format.toProperties(teapot)
+    stringyMap.get("a") should be("foo")
+    stringyMap.get("b") should be(42)
+    stringyMap.get("c") shouldBe true
+
+    format.fromProperties(stringyMap) should be(Right(teapot))
   }
+
 }

--- a/smbd/src/test/scala/StringyMapBigDataSpec.scala
+++ b/smbd/src/test/scala/StringyMapBigDataSpec.scala
@@ -7,7 +7,10 @@ import shapeless._
 import org.scalatest._
 import s4m.smbd.impl._
 
-case class Teapot(a: String, b: Int, c: Boolean)
+sealed trait Receptacle
+case class Teapot(a: String, b: Int, c: Boolean) extends Receptacle
+case class Bottle(foo: String, bar: Double) extends Receptacle
+case object Glass extends Receptacle
 
 class StringyMapBigDataSpec extends FlatSpec with Matchers {
 
@@ -20,6 +23,16 @@ class StringyMapBigDataSpec extends FlatSpec with Matchers {
     stringyMap.get("c") shouldBe true
 
     format.fromProperties(stringyMap) should be(Right(teapot))
+  }
+
+  "StringyMapBigData" should "marshall a sealed trait" in {
+    val teapot = Teapot("foo", 42, true)
+    val bottle = Bottle("hello", 1.23)
+    val glass = Glass
+    val format = implicitly[BigDataFormat[Receptacle]]
+    format.fromProperties(format.toProperties(teapot)) should be(Right(teapot))
+    format.fromProperties(format.toProperties(bottle)) should be(Right(bottle))
+    format.fromProperties(format.toProperties(glass)) should be(Right(glass))
   }
 
 }


### PR DESCRIPTION
I got it working fine for a single case class, but I couldn't get it work for sealed trait hierarchies.

```
[error] /Users/chris/code/shapeless-for-mortals/smbd/src/test/scala/StringyMapBigDataSpec.scala:32: could not find implicit value for parameter e: s4m.smbd.api.BigDataFormat[s4m.exercise1.Receptacle]
[error]     val format = implicitly[BigDataFormat[Receptacle]]
```

It's probably a silly mistake somewhere but I've hit the limit of my shapeless debugging skills.